### PR TITLE
Add tests for Layers

### DIFF
--- a/geonode.jsx
+++ b/geonode.jsx
@@ -78,6 +78,8 @@ var map = new ol.Map({
 class GeoNodeViewer extends React.Component {
   constructor(props) {
     super(props);
+  }
+  componentWillMount() {
     MapConfigService.load(MapConfigTransformService.transform(this.props.config), map);
   }
   getChildContext() {

--- a/tests/geonodeviewer.test.js
+++ b/tests/geonodeviewer.test.js
@@ -18,4 +18,24 @@ describe('GeoNodeViewer', () => {
 		const geonodeviewer = rendererWithIntl( <GeoNodeViewer config={config}/> );
 		assert.isDefined(ReactTestUtils.isCompositeComponent(geonodeviewer));
 	});
+	it('has a root div', () => {
+		const renderer = ReactTestUtils.createRenderer();
+		renderer.render(<GeoNodeViewer config={config} />);
+		let result = renderer.getRenderOutput();
+		assert.equal(result.type, 'div')
+	});
+  describe('one layer', () => {
+    beforeEach(() => {
+      config = { map: {
+        layers: [{"opacity": 1.0, "group": "background", "name": "mapnik", "visibility": true, "source": "0", "fixed": true, "type": "OpenLayers.Layer.OSM"}]
+      },
+      sources: { "0": {"ptype": "gxp_osmsource"} }
+      };
+    });
+    it('the layer list includes one layer', () => {
+			const geonodeviewer = ReactTestUtils.renderIntoDocument(<IntlProvider locale="en"><GeoNodeViewer config={config}/></IntlProvider>);
+      var contents = ReactTestUtils.scryRenderedDOMComponentsWithClass(geonodeviewer, 'layer-list');
+			assert.equal(contents[0].textContent,'Base Mapsmapnik');
+    });
+	});
 });

--- a/tests/geonodeviewer.test.js
+++ b/tests/geonodeviewer.test.js
@@ -24,7 +24,7 @@ describe('GeoNodeViewer', () => {
 		let result = renderer.getRenderOutput();
 		assert.equal(result.type, 'div')
 	});
-  describe('one layer', () => {
+  describe('OSM Layer', () => {
     beforeEach(() => {
       config = { map: {
         layers: [{"opacity": 1.0, "group": "background", "name": "mapnik", "visibility": true, "source": "0", "fixed": true, "type": "OpenLayers.Layer.OSM"}]
@@ -36,6 +36,39 @@ describe('GeoNodeViewer', () => {
 			const geonodeviewer = ReactTestUtils.renderIntoDocument(<IntlProvider locale="en"><GeoNodeViewer config={config}/></IntlProvider>);
       var contents = ReactTestUtils.scryRenderedDOMComponentsWithClass(geonodeviewer, 'layer-list');
 			assert.equal(contents[0].textContent,'Base Mapsmapnik');
+    });
+	});
+  describe('WMS Layer', () => {
+    beforeEach(() => {
+      config = { map: {
+        layers: [{"opacity": 1.0, "name": "geonode:Sprint_85", "title": "Sprint_85", "source": "1", "selected": true, "visibility": true, "srs": "EPSG:900913", "bbox": [-17821432.386584494, 1997190.3387437353, -7194334.231366029, 6275272.874913283], "getFeatureInfo": {"fields": ["DBA", "Technology"], "propertyNames": {"DBA": null, "Technology": null}}, "fixed": false, "queryable": true, "schema": [{"visible": true, "name": "the_geom"}, {"visible": true, "name": "DBA"}, {"visible": true, "name": "Technology"}]}]
+      },
+      sources: { "1": {"ptype": "gxp_wmscsource", "url": "http://exchange-dev.boundlessps.com/geoserver/wms", "restUrl": "/gs/rest", "isVirtualService": false, "title": "Local Geoserver"}}
+      };
+    });
+		it('layer list has one layer', () => {
+			const geonodeviewer = ReactTestUtils.renderIntoDocument(<IntlProvider locale="en"><GeoNodeViewer config={config}/></IntlProvider>);
+			var contents = ReactTestUtils.scryRenderedDOMComponentsWithClass(geonodeviewer, 'layer-list-item');
+			assert.equal(contents.length, 1);
+		});
+    it('the layer list includes layers name', () => {
+			const geonodeviewer = ReactTestUtils.renderIntoDocument(<IntlProvider locale="en"><GeoNodeViewer config={config}/></IntlProvider>);
+      var contents = ReactTestUtils.scryRenderedDOMComponentsWithClass(geonodeviewer, 'layer-list-item');
+			assert.equal(contents[0].textContent,'Sprint_85Remove layer');
+    });
+		describe('two layers', () => {
+			beforeEach(() => {
+				config = { map: {
+					layers: [{"opacity": 1.0, "name": "geonode:Sprint_85", "title": "Sprint_85", "source": "1", "selected": true, "visibility": true, "srs": "EPSG:900913", "bbox": [-17821432.386584494, 1997190.3387437353, -7194334.231366029, 6275272.874913283], "getFeatureInfo": {"fields": ["DBA", "Technology"], "propertyNames": {"DBA": null, "Technology": null}}, "fixed": false, "queryable": true, "schema": [{"visible": true, "name": "the_geom"}, {"visible": true, "name": "DBA"}, {"visible": true, "name": "Technology"}]},{"opacity": 1.0, "name": "geonode:Sprint_85", "title": "Sprint_85", "source": "1", "selected": true, "visibility": true, "srs": "EPSG:900913", "bbox": [-17821432.386584494, 1997190.3387437353, -7194334.231366029, 6275272.874913283], "getFeatureInfo": {"fields": ["DBA", "Technology"], "propertyNames": {"DBA": null, "Technology": null}}, "fixed": false, "queryable": true, "schema": [{"visible": true, "name": "the_geom"}, {"visible": true, "name": "DBA"}, {"visible": true, "name": "Technology"}]}]
+				},
+				sources: { "1": {"ptype": "gxp_wmscsource", "url": "http://exchange-dev.boundlessps.com/geoserver/wms", "restUrl": "/gs/rest", "isVirtualService": false, "title": "Local Geoserver"}}
+				};
+			});
+			it('layer list has two layer', () => {
+				const geonodeviewer = ReactTestUtils.renderIntoDocument(<IntlProvider locale="en"><GeoNodeViewer config={config}/></IntlProvider>);
+				var contents = ReactTestUtils.scryRenderedDOMComponentsWithClass(geonodeviewer, 'layer-list-item');
+				assert.equal(contents.length, 2);
+			});
     });
 	});
 });


### PR DESCRIPTION
## What does this PR do?

It adds the first tests to see if the config is being used and layers are added. 
There are two tests for layers. One for OSM layers and the other for simple WMS layers. 

Needed to refactor the `constructor` and added a `componentWillMount` method to change the state. 
A warning prevented the tests to pass: 

```
Warning: setState(...): Cannot update during an existing state transition (such as within "render" or another component's constructor). Render methods should be a pure function of props and state; constructor side-effects are an anti-pattern, but can be moved to "componentWillMount".
```
