### PR TITLE
Debug Viewer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - added tests & test setup
 - added CD via travis
 - added a `index-gh.html` with aboslute paths for repo
+- added abstraction `viewer` to easy the usage
+- added `componentWillReceiveProps` to geonodeViewer component
 
 ### Changed
 - moved viewer setup into `componentWillMount`

--- a/GeonodeDebug.jsx
+++ b/GeonodeDebug.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import GeoNodeViewer from './geonode.jsx';
+import enMessages from 'boundless-sdk/locale/en.js';
+import {IntlProvider} from 'react-intl';
+
+class GeoNodeViewerDebug extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { config: this.props.config };
+    this.config = JSON.stringify(this.props.config);
+    this.configUrl = '';
+  }
+  fetchConfigFromUrl(url) {
+    fetch(url).then((response) => {
+      return response.json();
+    }).then((json) => {
+      this.setState( { config: json});
+    });
+  }
+  configUrlChange(config) {
+    this.configUrl = config;
+    this.fetchConfigFromUrl('https://cors-anywhere.herokuapp.com/'+this.configUrl);
+  }
+  render() {
+    return (
+      <div>
+        <div id="debug">
+          <label for="debug">Debug URL</label>
+            <input
+            type="text"
+            value={this.configUrl}
+            onChange={(event) => { this.configUrlChange(event.target.value)}}
+          />
+        </div>
+        <GeoNodeViewer config={this.state.config} />
+      </div>
+    )
+  }
+}
+GeoNodeViewer.props = {
+  config: React.PropTypes.object.isRequired
+};
+export default GeoNodeViewerDebug;

--- a/app.css
+++ b/app.css
@@ -63,3 +63,20 @@ html, body {
   margin-left: 20px;
   top: 245px;
 }
+#debug {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	z-index: 10;
+	background: #ccc;
+	width: 100%;
+	height: 30px;
+	padding: 10px;
+	text-align: center;
+}
+#debug label {
+	margin-right: 10px;
+}
+#debug input {
+	width: 50%;
+}

--- a/app.jsx
+++ b/app.jsx
@@ -3,7 +3,9 @@ import ReactDOM from 'react-dom';
 import GeoNodeViewer from './geonode.jsx';
 import enMessages from 'boundless-sdk/locale/en.js';
 import {IntlProvider} from 'react-intl';
+import Viewer from './viewer.jsx';
 
 var config = {"defaultSourceType": "gxp_wmscsource", "about": {"abstract": "", "title": "Sprint Coverage"}, "map": {"layers": [{"opacity": 1.0, "group": "background", "name": "mapnik", "visibility": true, "source": "0", "fixed": true, "type": "OpenLayers.Layer.OSM"}, {"opacity": 1.0, "name": "geonode:Sprint_85", "title": "Sprint_85", "source": "1", "selected": true, "visibility": true, "srs": "EPSG:900913", "bbox": [-17821432.386584494, 1997190.3387437353, -7194334.231366029, 6275272.874913283], "getFeatureInfo": {"fields": ["DBA", "Technology"], "propertyNames": {"DBA": null, "Technology": null}}, "fixed": false, "queryable": true, "schema": [{"visible": true, "name": "the_geom"}, {"visible": true, "name": "DBA"}, {"visible": true, "name": "Technology"}]}], "center": [-8855994.09712052, 4469502.35491911], "units": "m", "maxResolution": 156543.03390625, "maxExtent": [-20037508.34, -20037508.34, 20037508.34, 20037508.34], "zoom": 2, "projection": "EPSG:900913"}, "id": 60, "sources": {"1": {"ptype": "gxp_wmscsource", "url": "http://exchange-dev.boundlessps.com/geoserver/wms", "restUrl": "/gs/rest", "isVirtualService": false, "title": "Local Geoserver"}, "0": {"ptype": "gxp_osmsource"}, "3": {"ptype": "gxp_olsource"}, "2": {"url": "http://exchange-dev.boundlessps.com/geoserver/wms", "restUrl": "/gs/rest", "ptype": "gxp_wmscsource", "title": "Local Geoserver"}, "4": {"url": "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/", "remote": true, "ptype": "gxp_wmscsource", "name": "ESRI"}}};
 
-ReactDOM.render(<IntlProvider locale='en' messages={enMessages}><GeoNodeViewer config={config} /></IntlProvider>, document.getElementById('main'));
+let viewer = new Viewer('main', config);
+viewer.view();

--- a/geonode.jsx
+++ b/geonode.jsx
@@ -87,6 +87,9 @@ class GeoNodeViewer extends React.Component {
       muiTheme: getMuiTheme()
     };
   }
+  componentWillReceiveProps(props) {
+    MapConfigService.load(MapConfigTransformService.transform(props.config), map);
+  }
   render() {
     return (
        <div id='content'>

--- a/viewer.jsx
+++ b/viewer.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import GeoNodeViewerDebug from './GeonodeDebug.jsx';
+import enMessages from 'boundless-sdk/locale/en.js';
+import {IntlProvider} from 'react-intl';
+
+class Viewer {
+  constructor(domId, config) {
+    this.domId = domId;
+    this.mapConfig = config;
+  }
+  set config(value) {
+    this.mapConfig = config;
+  }
+  view() {
+    ReactDOM.render(<IntlProvider locale='en' messages={enMessages}><GeoNodeViewerDebug config={this.mapConfig} /></IntlProvider>, document.getElementById(this.domId));
+  }
+}
+
+export default Viewer;


### PR DESCRIPTION
## What does this PR do?

It adds a debug field where you can put geonode config urls and they will be used to update the map.
- Adds a new GenodeViewerDebug Component to update the config
- Add `componentWillReceiveProps` to the GeonodeViewer
- Add abstraction `viewer` to create the react part.
## Screenshot

<img width="1174" alt="bildschirmfoto 2016-10-20 um 20 01 30" src="https://cloud.githubusercontent.com/assets/688980/19571895/1f390bb8-9700-11e6-91f2-445258ac4347.png">
