### PR TITLE
Use Proxy

### DIFF
--- a/GeonodeDebug.jsx
+++ b/GeonodeDebug.jsx
@@ -58,7 +58,7 @@ class GeoNodeViewerDebug extends React.Component {
             onChange={(event) => { this.configUrlChange(event.target.value)}}
           />
         </div>
-        <GeoNodeViewer config={this.state.config} />
+        <GeoNodeViewer config={this.state.config} proxy='https://cors-anywhere.herokuapp.com/'/>
       </div>
     )
   }

--- a/geonode.jsx
+++ b/geonode.jsx
@@ -80,11 +80,7 @@ class GeoNodeViewer extends React.Component {
     super(props);
   }
   updateMap(props) {
-    if(props.proxy) {
-      MapConfigService.load(MapConfigTransformService.transform(props.config, props.proxy), map);
-    } else {
-      MapConfigService.load(MapConfigTransformService.transform(props.config), map);
-    }
+    MapConfigService.load(MapConfigTransformService.transform(props.config, props.proxy), map);
   }
   componentWillMount() {
     this.updateMap(this.props);

--- a/geonode.jsx
+++ b/geonode.jsx
@@ -88,7 +88,7 @@ class GeoNodeViewer extends React.Component {
     };
   }
   componentWillReceiveProps(props) {
-    MapConfigService.load(MapConfigTransformService.transform(props.config), map);
+    MapConfigService.load(MapConfigTransformService.transform(props.config, 'https://cors-anywhere.herokuapp.com/'), map);
   }
   render() {
     return (

--- a/geonode.jsx
+++ b/geonode.jsx
@@ -79,8 +79,15 @@ class GeoNodeViewer extends React.Component {
   constructor(props) {
     super(props);
   }
+  updateMap(props) {
+    if(props.proxy) {
+      MapConfigService.load(MapConfigTransformService.transform(props.config, props.proxy), map);
+    } else {
+      MapConfigService.load(MapConfigTransformService.transform(props.config), map);
+    }
+  }
   componentWillMount() {
-    MapConfigService.load(MapConfigTransformService.transform(this.props.config), map);
+    this.updateMap(this.props);
   }
   getChildContext() {
     return {
@@ -88,7 +95,7 @@ class GeoNodeViewer extends React.Component {
     };
   }
   componentWillReceiveProps(props) {
-    MapConfigService.load(MapConfigTransformService.transform(props.config, 'https://cors-anywhere.herokuapp.com/'), map);
+    this.updateMap(props);
   }
   render() {
     return (
@@ -116,7 +123,8 @@ class GeoNodeViewer extends React.Component {
 }
 
 GeoNodeViewer.props = {
-  config: React.PropTypes.object.isRequired
+  config: React.PropTypes.object.isRequired,
+  proxy: React.PropTypes.string
 };
 
 GeoNodeViewer.childContextTypes = {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deploy": "npm run build:gh-pages && git-directory-deploy --directory _build --branch gh-pages"
   },
   "dependencies": {
-    "boundless-sdk": "^0.9.0",
+    "boundless-sdk": "github:boundlessgeo/sdk",
     "material-ui": "0.15.4",
     "ol3-cesium": "3.9.4",
     "openlayers": "~3.17.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "boundless-sdk": "^0.9.6",
     "material-ui": "0.15.4",
     "ol3-cesium": "3.9.4",
-    "openlayers": "~3.17.1",
+    "openlayers": "3.19.0",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-intl": "2.0.0-rc-1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deploy": "npm run build:gh-pages && git-directory-deploy --directory _build --branch gh-pages"
   },
   "dependencies": {
-    "boundless-sdk": "github:boundlessgeo/sdk",
+    "boundless-sdk": "^0.9.6",
     "material-ui": "0.15.4",
     "ol3-cesium": "3.9.4",
     "openlayers": "~3.17.1",


### PR DESCRIPTION
## What does this PR do?

Specifies a proxy from which the sources should be loaded/proxied through. 
Since many Geonodes do not have CORS support we need a proxy do display them all. 
It now allows us to use almost any geonode config and test it out.
## Screenshot

<img width="947" alt="bildschirmfoto 2016-10-24 um 18 08 11" src="https://cloud.githubusercontent.com/assets/688980/19680906/ae86774c-9aa7-11e6-8de2-1a956c1ea4ed.png">
## Related Issue

closes #11 
