### PR TITLE
Use terranodo proxy

### DIFF
--- a/GeonodeDebug.jsx
+++ b/GeonodeDebug.jsx
@@ -58,7 +58,7 @@ class GeoNodeViewerDebug extends React.Component {
             onChange={(event) => { this.configUrlChange(event.target.value)}}
           />
         </div>
-        <GeoNodeViewer config={this.state.config} proxy='https://cors-anywhere.herokuapp.com/'/>
+        <GeoNodeViewer config={this.state.config} proxy='http://cors-anywhere.cfapps.io/'/>
       </div>
     )
   }


### PR DESCRIPTION
## What does this PR do?

Uses a terranodo proxy on cloudfoundry. 
only the viewer.geonode.org is whitelisted for this proxy as the origin
