### PR TITLE
Add scalebar to viewer, make sure attribution shows up

### DIFF
--- a/app.css
+++ b/app.css
@@ -21,7 +21,7 @@ html, body {
 /* end Dead Simple Grid */
 #map {
   width: 100%;
-  height: 100%;
+  height: calc(100% - 56px);
 }
 #content, #main {
   width: 100%;
@@ -69,10 +69,10 @@ html, body {
 #debug {
 	position: absolute;
 	bottom: 0;
-	left: 0;
+	left: 25%;
 	z-index: 10;
-	background: #ccc;
-	width: 100%;
+	background: rgba(204,204,204, 0.8);
+	width: 50%;
 	height: 30px;
 	padding: 10px;
 	text-align: center;

--- a/geonode.jsx
+++ b/geonode.jsx
@@ -109,7 +109,7 @@ class GeoNodeViewer extends React.Component {
         <div id='globe-button'><Globe tooltipPosition='right' map={map} /></div>
         <div><PanelButton className='legenddiv' contentClassName='legendcontent' buttonClassName='legend-button' icon={<LegendIcon />} tooltipPosition='top-left' buttonTitle='Show legend' map={map} content={<Legend map={map} />}/></div>
         <div id='home-button'><HomeButton tooltipPosition='right' map={map} /></div>
-        <div><LayerList tooltipPosition='top-left' allowStyling={true} map={map} /></div>
+        <div><LayerList allowRemove={false} tooltipPosition='top-left' allowStyling={true} map={map} /></div>
         <div id='zoom-buttons'><Zoom tooltipPosition='right' map={map} /></div>
         <div id='rotate-button'><Rotate tooltipPosition='top-left' map={map} /></div>
         <div id='popup' className='ol-popup'><InfoPopup toggleGroup='navigation' toolId='nav' infoFormat='application/vnd.ogc.gml' map={map} /></div>

--- a/geonode.jsx
+++ b/geonode.jsx
@@ -68,7 +68,7 @@ addLocaleData(
 );
 
 var map = new ol.Map({
-  controls: [new ol.control.Attribution({collapsible: false})],
+  controls: [new ol.control.Attribution({collapsible: false}), new ol.control.ScaleLine()],
   view: new ol.View({
     center: [0, 0],
     zoom: 4


### PR DESCRIPTION
## Whart does this PR do?

Adds a scalebar to the viewer. Makes sure attribution control shows up (was below the page before).
## Screenshot

![screen shot 2016-10-27 at 13 37 54](https://cloud.githubusercontent.com/assets/319678/19765799/994b5970-9c4a-11e6-993d-9585872c80eb.png)
## Related Issue
