### PR TITLE
Use OSM as default if no map config

### DIFF
--- a/geonode.jsx
+++ b/geonode.jsx
@@ -63,7 +63,11 @@ addLocaleData(
 );
 
 var map = new ol.Map({
-  controls: [new ol.control.Attribution({collapsible: false}), new ol.control.ScaleLine()]
+  controls: [new ol.control.Attribution({collapsible: false}), new ol.control.ScaleLine()],
+  layers: [
+    new ol.layer.Tile({title: 'OpenStreetMap', source: new ol.source.OSM()})
+  ],
+  view: new ol.View({center: [0, 0], zoom: 1})
 });
 
 class GeoNodeViewer extends React.Component {


### PR DESCRIPTION
## Whart does this PR do?
Has OSM as the default map instead of no map at all.

## Screenshot
![screen shot 2016-11-03 at 13 38 43](https://cloud.githubusercontent.com/assets/319678/19966161/dd5a1cca-a1ca-11e6-8b0b-e5dbdab3d7ab.png)


## Related Issue

