### PR TITLE
Show to user when config contains errors

### DIFF
--- a/app.css
+++ b/app.css
@@ -66,7 +66,7 @@ html, body {
 }
 #debug {
 	position: absolute;
-	bottom: 0;
+	top: 0;
 	left: 25%;
 	z-index: 10;
 	background: rgba(204,204,204, 0.8);


### PR DESCRIPTION
## Whart does this PR do?
Shows a snackbar (and logs info to the console) to the end user if map config contains "errors".
Moves the debug input to the top so it does not interfere with the snackbar (and it won't be in the end viewer anyway the debug input).

## Screenshot


## Related Issue
closes #43 
