### PR TITLE
Add Composer to the Client

### DIFF
--- a/index-composer.html
+++ b/index-composer.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <base target="_blank">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" >
+  <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en,Object.assign"></script>
+  <script src="/js/cesium/Cesium.js" type="text/javascript" charset="utf-8"></script>
+</head>
+<body>
+  <div id='main'></div>
+  <script src="/js/composer.js"></script>
+  <script >
+		var v = new this.Composer('main');
+		v.view();
+	</script>
+</body>
+</html>
+

--- a/index-gh.html
+++ b/index-gh.html
@@ -12,7 +12,7 @@
   <script src="/js/app.js"></script>
   <script >
     var config = {"defaultSourceType": "gxp_wmscsource", "about": {"abstract": "", "title": "Sprint Coverage"}, "map": {"layers": [{"opacity": 1.0, "group": "background", "name": "mapnik", "visibility": true, "source": "0", "fixed": true, "type": "OpenLayers.Layer.OSM"}, {"opacity": 1.0, "name": "geonode:Sprint_85", "title": "Sprint_85", "source": "1", "selected": true, "visibility": true, "srs": "EPSG:900913", "bbox": [-17821432.386584494, 1997190.3387437353, -7194334.231366029, 6275272.874913283], "getFeatureInfo": {"fields": ["DBA", "Technology"], "propertyNames": {"DBA": null, "Technology": null}}, "fixed": false, "queryable": true, "schema": [{"visible": true, "name": "the_geom"}, {"visible": true, "name": "DBA"}, {"visible": true, "name": "Technology"}]}], "center": [-8855994.09712052, 4469502.35491911], "units": "m", "maxResolution": 156543.03390625, "maxExtent": [-20037508.34, -20037508.34, 20037508.34, 20037508.34], "zoom": 4, "projection": "EPSG:900913"}, "id": 60, "sources": {"1": {"ptype": "gxp_wmscsource", "url": "http://exchange-dev.boundlessps.com/geoserver/wms", "restUrl": "/gs/rest", "isVirtualService": false, "title": "Local Geoserver"}, "0": {"ptype": "gxp_osmsource"}, "3": {"ptype": "gxp_olsource"}, "2": {"url": "http://exchange-dev.boundlessps.com/geoserver/wms", "restUrl": "/gs/rest", "ptype": "gxp_wmscsource", "title": "Local Geoserver"}, "4": {"url": "http://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/", "remote": true, "ptype": "gxp_wmscsource", "name": "ESRI"}}};
-		var v = new this.viewer('main', config);
+		var v = new this.Viewer('main', config);
 		v.view();
 	</script>
 </body>

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "start": "mkdir -p dist && node_modules/.bin/webpack-dev-server --progress --colors",
     "build:js": "webpack",
-    "build:gh-copy": "cp index-gh.html _build/index.html && cp dist/viewer.js _build/js/app.js && cp -r resources/ol3-cesium/* _build/js/cesium/ && cp CNAME _build/CNAME",
+    "build:gh-copy": "cp index-gh.html _build/index.html && cp dist/viewer.js _build/js/app.js && cp dist/composer.js _build/js/composer.js && cp -r resources/ol3-cesium/* _build/js/cesium/ && cp CNAME _build/CNAME && cp index-composer.html _build/composer/index.html",
     "build:gh-clean": "rm -rf _build/* ",
-    "build:gh-makedir": "mkdir -p _build && mkdir -p _build/js && mkdir -p _build/css && mkdir -p _build/js/cesium",
+    "build:gh-makedir": "mkdir -p _build && mkdir -p _build/js && mkdir -p _build/css && mkdir -p _build/js/cesium && mkdir -p _build/composer",
     "build:gh-pages": "npm run build && npm run build:gh-clean && npm run build:gh-makedir && npm run build:gh-copy",
     "build": "mkdir -p dist && npm run build:js",
 		"dist:build": "BUILD_PROD=1 webpack",

--- a/src/composer.jsx
+++ b/src/composer.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import GeoNodeViewer from './geonode.jsx';
+import enMessages from 'boundless-sdk/locale/en.js';
+import {IntlProvider} from 'react-intl';
+
+class Composer {
+  constructor(domId, config) {
+    this._domId = domId;
+    this._mapConfig = config;
+    this._proxy = undefined;
+  }
+  set mapConfig(value) {
+    this._mapConfig = value;
+  }
+  set proxy(value) {
+    this._proxy = value;
+  }
+  view() {
+    ReactDOM.render(<IntlProvider locale='en' messages={enMessages}><GeoNodeViewer mode='composer' config={this._mapConfig} proxy={this._proxy} /></IntlProvider>, document.getElementById(this._domId));
+  }
+}
+
+module.exports = Composer;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,19 +5,22 @@ var BUILD_DIR = path.resolve(__dirname, 'dist');
 var APP_DIR = path.resolve(__dirname, '.');
 
 var plugins = [];
-var filename = BUILD_DIR + '/viewer.js';
+var filename = BUILD_DIR + '/[name].js';
 var PROD = JSON.parse(process.env.BUILD_PROD || false);
 if(PROD) {
   plugins.push(new webpack.DefinePlugin({ 'process.env': { 'NODE_ENV': JSON.stringify('production') } }));
   plugins.push(new webpack.optimize.UglifyJsPlugin({ compress:{ warnings: true } }));
-  filename = BUILD_DIR + '/viewer.min.js';
+  filename = BUILD_DIR + '/[name].min.js';
 }
 
 module.exports = {
-	entry: APP_DIR + '/src/viewer.jsx',
+	entry: {
+    Viewer: APP_DIR + '/src/viewer.jsx',
+    Composer: APP_DIR + '/src/composer.jsx'
+  },
 	output: {
     filename: filename,
-    library: 'viewer',
+    library: '[name]',
     libraryTarget: 'umd',
     umdNamedDefine: true
 	},


### PR DESCRIPTION
## What does this PR do?
Adds the composer into this repo as well. For now it's generating two files from the same `geonode.jsx`, one is composer and one is the viewer. It uses modes to differentiate those two and sets `editing` to true or false. 

### Worth discussing:
Is that the right approach. I think we should have one repo for both but should we have two different react files/components or just two js files that abstract react. 