### PR TITLE
Fix the possibility of a trailing slash in the server url

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -5,3 +5,9 @@ export const getCRSFToken = () => {
   }
   return csrfToken;
 };
+export const hasTrailingSlash = (str) => {
+  return (/.*\/$/).test(str);
+};
+export const removeTrailingSlash = (str) => {
+  return hasTrailingSlash(str) ? str.slice(0, -1) : str;
+};

--- a/src/reducers/actions.js
+++ b/src/reducers/actions.js
@@ -1,6 +1,6 @@
 import MapConfigTransformService from 'boundless-sdk/services/MapConfigTransformService';
 import MapConfigService from 'boundless-sdk/services/MapConfigService';
-import {getCRSFToken} from '../helper'
+import {getCRSFToken, removeTrailingSlash} from '../helper'
 
 import 'whatwg-fetch'
 
@@ -55,7 +55,7 @@ export const saveMap = (map) => {
       },
       body: JSON.stringify(state.mapConfig)
     };
-    return fetch(state.server + '/maps/new/data',myInit)
+    return fetch(removeTrailingSlash(state.server) + '/maps/new/data',myInit)
     .then((response) => response.json())
     .then((json) => dispatch(saveMapSuccess(json)))
     .catch(ex => dispatch(saveMapError(ex)));

--- a/tests/helper.test.js
+++ b/tests/helper.test.js
@@ -3,14 +3,31 @@ import raf from 'raf';
 raf.polyfill();
 import {assert} from 'chai';
 
-import {getCRSFToken} from '../src/helper';
+import {getCRSFToken, hasTrailingSlash, removeTrailingSlash} from '../src/helper';
 
 describe('getCRSFToken', () => {
-  let map;
   beforeEach(function() {
-		document.cookie = "csrftoken=1;"
+		document.cookie = "csrftoken=1;";
   });
 	it('returns csrftoken from cookie', () => {
 		assert.equal(getCRSFToken(),'1');
+	});
+});
+
+describe('hasTrailingSlash', () => {
+	it('returns true if a trailing slash is detected', () => {
+		assert.equal(hasTrailingSlash('test/'),true);
+	});
+	it('returns false if no trailing slash is detected', () => {
+		assert.equal(hasTrailingSlash('test'),false);
+	});
+});
+
+describe('removeTrailingSLash', () => {
+	it('returns str without trailing slash', () => {
+		assert.equal(removeTrailingSlash('test/'),'test');
+	});
+	it('returns str without trailing slash', () => {
+		assert.equal(removeTrailingSlash('test'),'test');
 	});
 });

--- a/tests/reducers/actions.test.js
+++ b/tests/reducers/actions.test.js
@@ -52,5 +52,19 @@ describe('actions', () => {
         assert.deepEqual(store.getActions()[0].type, types.SAVE_MAP_ERROR);
       });
     });
+    describe('server with trailing slash', () => {
+      it('calls SAVE_MAP_SUCCESS', () => {
+        fetchMock
+        .mock('http://geonode.org/maps/new/data', {result: ''});
+        const store = mockStore({ server: 'http://geonode.org/', mapConfig: {data: '' } });
+        const expectedActions = [
+          { type: types.SAVE_MAP_SUCCESS, body: { result: '' }}
+        ];
+        return store.dispatch(actions.saveMap())
+        .then(() => {
+          assert.deepEqual(store.getActions(), expectedActions);
+        });
+      });
+    });
   })
 });


### PR DESCRIPTION
## What does this PR do?
The `SITEURL` can have a trailing slkash or not. make sure we don't include double slashes.

Add methods to remove trailing slash if a trailing is detected
add tests for both the methods and the saveMap method
