### PR TITLE
Proxy argument was removed from transform

### DIFF
--- a/src/components/geonode.jsx
+++ b/src/components/geonode.jsx
@@ -101,7 +101,7 @@ class GeoNodeViewer extends React.Component {
     if (props.config) {
       var errors = [];
       var filteredErrors = [];
-      MapConfigService.load(MapConfigTransformService.transform(props.config, props.proxy, errors), map, this.props.proxy);
+      MapConfigService.load(MapConfigTransformService.transform(props.config, errors), map, this.props.proxy);
       for (var i = 0, ii = errors.length; i < ii; ++i) {
         // ignore the empty baselayer since we have checkbox now for base layer group
         if (errors[i].layer.type !== 'OpenLayers.Layer') {


### PR DESCRIPTION
## Whart does this PR do?
Fix the call to transform on MapConfigTransformService in case of errors
The proxy argument was removed from the transform function in sdk since it's not used anymore: https://github.com/boundlessgeo/sdk/blob/master/js/services/MapConfigTransformService.js#L166

## Screenshot

## Related Issue
