### PR TITLE
Have layer detail page zoom to layer

### DIFF
--- a/geonode-client/templates/geonode-client/layer_map.html
+++ b/geonode-client/templates/geonode-client/layer_map.html
@@ -39,10 +39,11 @@
         tools: [{ptype: "gxp_getfeedfeatureinfo"}],
 		};
 		var config = Object.assign( defaultConfig, {{ viewer|safe }});
-    var viewer = new window.Viewer('preview_map', config);
-    if(config.proxy !== '') {
-      viewer.proxy = "{{PROXY_URL}}";
+    var options = {mapConfig: config, zoomToLayer: true};
+    if (config.proxy !== '') {
+      options.proxy = "{{PROXY_URL}}";
     }
+    var viewer = new window.Viewer('preview_map', options);
     viewer.view();
 });
 </script>

--- a/geonode-client/templates/geonode-client/map_detail.html
+++ b/geonode-client/templates/geonode-client/map_detail.html
@@ -41,10 +41,11 @@
         tools: [{ptype: "gxp_getfeedfeatureinfo"}],
 		};
 		var config = Object.assign( defaultConfig, {{ config|safe }});
-    var viewer = new window.Viewer('the_map', config);
-    if(config.proxy !== '') {
-      viewer.proxy = "{{PROXY_URL}}";
+    var options = {mapConfig: config};
+    if (config.proxy !== '') {
+      options.proxy = "{{PROXY_URL}}";
     }
+    var viewer = new window.Viewer('the_map', options);
     viewer.view();
 	});
 </script>

--- a/geonode-client/templates/geonode-client/map_edit.html
+++ b/geonode-client/templates/geonode-client/map_edit.html
@@ -43,16 +43,15 @@
         tools: [{ptype: "gxp_getfeedfeatureinfo"}],
     };
 		var config = Object.assign( defaultConfig, {{ config|safe }});
-		var composer = new window.Composer('client-composer-map', "{{SITEURL}}");
-		composer.mapConfig = config;
-		composer.mapId = "{{mapId}}";
-    var layerSources = [
-      {title: 'Local GeoServer', url: "{{ GEOSERVER_BASE_URL }}ows/", type: 'WMS'}
-    ];
-    if(config.proxy !== '') {
-      composer.proxy = "{{PROXY_URL}}";
-    }
-    composer.compose(layerSources);
+		var options = {server: "{{SITEURL}}", mapConfig: config, mapId: "{{mapId}}"};
+		if (config.proxy !== '') {
+			options.proxy = "{{PROXY_URL}}";
+		}
+		var composer = new window.Composer('client-composer-map', options);
+		var layerSources = [
+			{title: 'Local GeoServer', url: "{{ GEOSERVER_BASE_URL }}ows/", type: 'WMS'}
+		];
+		composer.compose(layerSources);
 	});
 </script>
 <div id="client-composer-map">

--- a/geonode-client/templates/geonode-client/map_new.html
+++ b/geonode-client/templates/geonode-client/map_new.html
@@ -47,14 +47,13 @@
         tools: [{ptype: "gxp_getfeedfeatureinfo"}],
     };
 		var config = Object.assign( defaultConfig, {{ config|safe }});
-		var composer = new window.Composer('client-composer-map', "{{SITEURL}}");
-    var layerSources = [
-      {title: 'Local GeoServer', url: "{{ GEOSERVER_BASE_URL }}ows/", type: 'WMS'}
-    ];
-    if(config.proxy !== '') {
-      composer.proxy = "{{PROXY_URL}}";
-    }
-    composer.compose(layerSources);
+		var options = {server: "{{SITEURL}}"};
+		if (config.proxy !== '') {
+			options.proxy = "{{PROXY_URL}}";
+		}
+		var composer = new window.Composer('client-composer-map', options);
+    		var layerSources = [{title: 'Local GeoServer', url: "{{ GEOSERVER_BASE_URL }}ows/", type: 'WMS'}];
+    		composer.compose(layerSources);
 	});
 </script>
 <div id="client-composer-map">

--- a/geonode-client/templates/geonode-client/map_view.html
+++ b/geonode-client/templates/geonode-client/map_view.html
@@ -47,10 +47,11 @@
         tools: [{ptype: "gxp_getfeedfeatureinfo"}],
 		};
 		var config = Object.assign( defaultConfig, {{ config|safe }});
-    var viewer = new window.Viewer('client-viewer-map', config);
-    if(config.proxy !== '') {
-      viewer.proxy = "{{PROXY_URL}}";
+    var options = {mapConfig: config};
+    if (config.proxy !== '') {
+      options.proxy = "{{PROXY_URL}}";
     }
+    var viewer = new window.Viewer('client-viewer-map', options);
     viewer.view();
 	});
 </script>

--- a/src/components/geonode.jsx
+++ b/src/components/geonode.jsx
@@ -101,6 +101,9 @@ class GeoNodeViewer extends React.Component {
     if (props.config) {
       var errors = [];
       var filteredErrors = [];
+      if (props.zoomToLayer && props.config.map.layers[props.config.map.layers.length - 1].bbox) {
+        this._extent = props.config.map.layers[props.config.map.layers.length - 1].bbox;
+      }
       MapConfigService.load(MapConfigTransformService.transform(props.config, errors), map, this.props.proxy);
       for (var i = 0, ii = errors.length; i < ii; ++i) {
         // ignore the empty baselayer since we have checkbox now for base layer group
@@ -149,7 +152,7 @@ class GeoNodeViewer extends React.Component {
     return (
        <div id='content'>
         {error}
-        <MapPanel useHistory={true} id='map' map={map} />
+        <MapPanel useHistory={true} id='map' map={map} extent={this._extent} />
         <div id='globe-button'><Globe tooltipPosition='right' map={map} /></div>
         <div id='print-button'><QGISPrint menu={false} map={map} layouts={printLayouts} /></div>
         <div id='home-button'><HomeButton tooltipPosition='right' map={map} /></div>

--- a/src/composer.jsx
+++ b/src/composer.jsx
@@ -12,12 +12,12 @@ import {setMapConfig} from './state/mapConfig/actions';
 const store = configureStore();
 
 class Composer {
-  constructor(domId, server) {
+  constructor(domId, options) {
     this._domId = domId;
-    this._mapConfig = undefined;
-    this._server = server;
-    this._proxy = undefined;
-    this._mapId = undefined;
+    this._mapConfig = options.mapConfig;
+    this._server = options.server;
+    this._proxy = options.proxy;
+    this._mapId = options.mapId;
   }
   set server(value) {
     this._server = value;

--- a/src/viewer.jsx
+++ b/src/viewer.jsx
@@ -5,10 +5,11 @@ import enMessages from 'boundless-sdk/locale/en.js';
 import {IntlProvider} from 'react-intl';
 
 class Viewer {
-  constructor(domId, config) {
+  constructor(domId, options) {
     this._domId = domId;
-    this._mapConfig = config;
-    this._proxy = undefined;
+    this._mapConfig = options.mapConfig;
+    this._proxy = options.proxy;
+    this._zoomToLayer = options.zoomToLayer;
   }
   set mapConfig(value) {
     this._mapConfig = value;
@@ -16,8 +17,11 @@ class Viewer {
   set proxy(value) {
     this._proxy = value;
   }
+  set zoomToLayer(value) {
+    this._zoomToLayer = value;
+  }
   view() {
-    ReactDOM.render(<IntlProvider locale='en' messages={enMessages}><GeoNodeViewer config={this._mapConfig} proxy={this._proxy} /></IntlProvider>, document.getElementById(this._domId));
+    ReactDOM.render(<IntlProvider locale='en' messages={enMessages}><GeoNodeViewer zoomToLayer={this._zoomToLayer} config={this._mapConfig} proxy={this._proxy} /></IntlProvider>, document.getElementById(this._domId));
   }
 }
 


### PR DESCRIPTION
## Whart does this PR do?
Refactors all constructors to take a single options object.
Zooms to the layer extent on the layer detail page.

## Screenshot
![selection_027](https://cloud.githubusercontent.com/assets/319678/22119860/78444d5c-de7d-11e6-9d30-43f875e15ab7.png)


## Related Issue
closes #84 