### PR TITLE
Fix failing travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ node_js:
 - '6'
 script:
 - npm run test
-- codeclimate-test-reporter < reports/coverage/lcov.info
 before_script:
 - git config --global user.email "mila.frerichs@gmail.com"
 - git config --global user.name "Mila Frerichs"
 - git remote rm origin
 - git remote add origin https://milafrerichs:${GH_TOKEN}@github.com/GeoNode/geonode-client.git
 after_success:
-- "./.travis/deploy.sh"
+- "[[ $TRAVIS_BRANCH =~ (master|^v[0-9]+.[0-9]+) && $TRAVIS_PULL_REQUEST == 'false']] && npm run deploy"
+- "[[ $TRAVIS_BRANCH =~ (master|^v[0-9]+.[0-9]+) ]] && codeclimate-test-reporter < reports/coverage/lcov.info"
 cache:
   directories:
   - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 - git remote rm origin
 - git remote add origin https://milafrerichs:${GH_TOKEN}@github.com/GeoNode/geonode-client.git
 after_success:
-- "[[ $TRAVIS_BRANCH =~ (master|^v[0-9]+.[0-9]+) && $TRAVIS_PULL_REQUEST == 'false']] && npm run deploy"
+- "if [[ $TRAVIS_BRANCH =~ (master|^v[0-9]+.[0-9]+)] && $TRAVIS_PULL_REQUEST == 'false' ]]; then npm run deploy; fi;"
 - "[[ $TRAVIS_BRANCH =~ (master|^v[0-9]+.[0-9]+) ]] && codeclimate-test-reporter < reports/coverage/lcov.info"
 cache:
   directories:


### PR DESCRIPTION
## What does this PR do?
Fix the failing travis builds from forks.
when someone from a fork tries to submit a PR it fails due to
codeclimate config not beeing available
fix that with only running the codeclimate after success and only on
master and tags
change the deploy script to be travis inline to make it clear what it
does since we can do all the thing the script is doing inline