### PR TITLE
Pass in X-CSRFToken as a request header

### DIFF
--- a/src/components/geonode.jsx
+++ b/src/components/geonode.jsx
@@ -27,6 +27,7 @@ global.enMessages = enMessages;
 import Save from './save';
 import MapUrlLink from '../containers/MapUrlLink';
 import {getLocalGeoServer} from '../services/geonode';
+import {getCRSFToken} from '../helper';
 
 import '../css/app.css'
 import 'boundless-sdk/dist/css/components.css';
@@ -61,6 +62,7 @@ class GeoNodeViewer extends React.Component {
   getChildContext() {
     return {
       proxy: this.props.proxy,
+      requestHeaders: {'X-CSRFToken': getCRSFToken()},
       muiTheme: getMuiTheme(this.props.theme)
     };
   }
@@ -187,6 +189,7 @@ GeoNodeViewer.defaultProps = {
 
 GeoNodeViewer.childContextTypes = {
   proxy: React.PropTypes.string,
+  requestHeaders: React.PropTypes.object,
   muiTheme: React.PropTypes.object
 };
 


### PR DESCRIPTION
## Whart does this PR do?
Pass in the X-CSRFToken as a request header to the sdk
Will only work when https://github.com/boundlessgeo/sdk/pull/373 is merged and released

## Screenshot
![selection_066](https://cloud.githubusercontent.com/assets/319678/22591342/64211556-ea14-11e6-8fd7-5162f2b933ea.png)


## Related Issue
