### PR TITLE
Ignore undefined layer

### DIFF
--- a/src/components/geonode.jsx
+++ b/src/components/geonode.jsx
@@ -87,7 +87,8 @@ class GeoNodeViewer extends React.Component {
       MapConfigService.load(MapConfigTransformService.transform(props.config, errors, tileServices), map, this.props.proxy);
       for (var i = 0, ii = errors.length; i < ii; ++i) {
         // ignore the empty baselayer since we have checkbox now for base layer group
-        if (errors[i].layer.type !== 'OpenLayers.Layer') {
+        // ignore the empty layer from the local source
+        if (errors[i].layer.type !== 'OpenLayers.Layer' && errors[i].msg !== 'Unable to load layer undefined') {
           if (window.console && window.console.warn) {
             window.console.warn(errors[i]);
           }


### PR DESCRIPTION
## Whart does this PR do?
Ignore the undefined layer in the config, i.e. a local WMS layer with no name, that GeoNode puts in the config

## Screenshot

## Related Issue
#160 