### PR TITLE
Detect config variable for specifying cross origin requests for map t…

### DIFF
--- a/geonode-client/templates/geonode-client/layer_map.html
+++ b/geonode-client/templates/geonode-client/layer_map.html
@@ -43,6 +43,11 @@
     if (config.proxy !== '') {
       options.proxy = "{{PROXY_URL}}";
     }
+    if ("{{ MAP_CLIENT_USE_CROSS_ORIGIN_CREDENTIALS }}" == 'True') {
+      options.crossOriginCredentials = true;
+    } else {
+      options.crossOriginCredentials = false;
+    }
     var viewer = new window.Viewer('preview_map', options);
     viewer.view();
 });

--- a/geonode-client/templates/geonode-client/map_detail.html
+++ b/geonode-client/templates/geonode-client/map_detail.html
@@ -45,6 +45,11 @@
     if (config.proxy !== '') {
       options.proxy = "{{PROXY_URL}}";
     }
+    if ("{{ MAP_CLIENT_USE_CROSS_ORIGIN_CREDENTIALS }}" == 'True') {
+      options.crossOriginCredentials = true;
+    } else {
+      options.crossOriginCredentials = false;
+    }
     var viewer = new window.Viewer('the_map', options);
     viewer.view();
 	});

--- a/geonode-client/templates/geonode-client/map_new.html
+++ b/geonode-client/templates/geonode-client/map_new.html
@@ -54,6 +54,11 @@
 		if (config.proxy !== '') {
 			options.proxy = "{{PROXY_URL}}";
 		}
+        if ("{{ MAP_CLIENT_USE_CROSS_ORIGIN_CREDENTIALS }}" == 'True') {
+          options.crossOriginCredentials = true;
+        } else {
+          options.crossOriginCredentials = false;
+        }
 		var composer = new window.Composer('client-composer-map', options);
     		composer.compose();
 	});

--- a/geonode-client/templates/geonode-client/map_view.html
+++ b/geonode-client/templates/geonode-client/map_view.html
@@ -51,6 +51,11 @@
     if (config.proxy !== '') {
       options.proxy = "{{PROXY_URL}}";
     }
+    if ("{{ MAP_CLIENT_USE_CROSS_ORIGIN_CREDENTIALS }}" == 'True') {
+      options.crossOriginCredentials = true;
+    } else {
+      options.crossOriginCredentials = false;
+    }
     var viewer = new window.Viewer('client-viewer-map', options);
     viewer.view();
 	});

--- a/src/components/geonode.jsx
+++ b/src/components/geonode.jsx
@@ -93,7 +93,7 @@ class GeoNodeViewer extends React.Component {
       if (props.zoomToLayer && props.config.map.layers[props.config.map.layers.length - 1].bbox) {
         this._extent = props.config.map.layers[props.config.map.layers.length - 1].bbox;
       }
-      MapConfigService.load(MapConfigTransformService.transform(props.config, errors, tileServices), map, this.props.proxy);
+      MapConfigService.load(MapConfigTransformService.transform(props.config, errors, tileServices, props.crossOriginCredentials), map, this.props.proxy);
       for (var i = 0, ii = errors.length; i < ii; ++i) {
         // ignore the empty baselayer since we have checkbox now for base layer group
         // ignore the empty layer from the local source
@@ -185,7 +185,8 @@ GeoNodeViewer.props = {
   theme: React.PropTypes.object,
   mode: React.PropTypes.string,
   server: React.PropTypes.string,
-  printLayouts: React.PropTypes.array
+  printLayouts: React.PropTypes.array,
+  crossOriginCredentials: React.PropTypes.bool
 };
 
 GeoNodeViewer.defaultProps = {

--- a/src/composer.jsx
+++ b/src/composer.jsx
@@ -23,6 +23,7 @@ class Composer {
     this._printLayouts = options.printLayouts;
     this._theme = options.theme;
     this._baseUrl = options.baseUrl;
+    this._crossOriginCredentials = options.crossOriginCredentials;
   }
   set server(value) {
     this._server = value;
@@ -48,7 +49,7 @@ class Composer {
     store.dispatch(setMapConfig(this._mapConfig));
     store.dispatch(setCheckLogin(this._checkLogin));
     store.dispatch(setUserLoggedIn(this._userLoggedIn));
-    ReactDOM.render(<Provider store={store}><IntlProvider locale='en' messages={enMessages}><GeonodeComposer baseUrl={this._baseUrl} theme={this._theme} printLayouts={this._printLayouts} mode='composer' config={this._mapConfig} proxy={this._proxy} /></IntlProvider></Provider>, document.getElementById(this._domId));
+    ReactDOM.render(<Provider store={store}><IntlProvider locale='en' messages={enMessages}><GeonodeComposer baseUrl={this._baseUrl} theme={this._theme} printLayouts={this._printLayouts} mode='composer' config={this._mapConfig} proxy={this._proxy} crossOriginCredentials={this._crossOriginCredentials} /></IntlProvider></Provider>, document.getElementById(this._domId));
   }
 }
 

--- a/src/viewer.jsx
+++ b/src/viewer.jsx
@@ -12,6 +12,7 @@ class Viewer {
     this._zoomToLayer = options.zoomToLayer;
     this._printLayouts = options.printLayouts;
     this._theme = options.theme;
+    this._crossOriginCredentials = options.crossOriginCredentials;
   }
   set mapConfig(value) {
     this._mapConfig = value;
@@ -29,7 +30,7 @@ class Viewer {
     this._theme = value;
   }
   view() {
-    ReactDOM.render(<IntlProvider locale='en' messages={enMessages}><GeoNodeViewer theme={this._theme} printLayouts={this._printLayouts} zoomToLayer={this._zoomToLayer} config={this._mapConfig} proxy={this._proxy} /></IntlProvider>, document.getElementById(this._domId));
+    ReactDOM.render(<IntlProvider locale='en' messages={enMessages}><GeoNodeViewer theme={this._theme} printLayouts={this._printLayouts} zoomToLayer={this._zoomToLayer} config={this._mapConfig} proxy={this._proxy} crossOriginCredentials={this._crossOriginCredentials} /></IntlProvider>, document.getElementById(this._domId));
   }
 }
 


### PR DESCRIPTION
…ile requests in viewer

## Whart does this PR do?
Gives the Viewer the capability to specify that the SDK should make cross origin requests. This is added in a property granted via a settings boolean in GeoNode, `CROSS_ORIGIN`.

This PR requires the SDK PR merged: https://github.com/boundlessgeo/sdk/pull/618
It also coincides with the GeoNode PR: https://github.com/GeoNode/geonode/pull/3222
Exchange PR: https://github.com/boundlessgeo/exchange/pull/346

## Screenshot
N/A

## Related Issue
[NODE-1082](https://issues.boundlessgeo.com:8443/browse/NODE-1082)
