### PR TITLE
Workaround for bad use-credentials CORS requests when service does no…

### DIFF
--- a/geonode-client/templates/geonode-client/layer_map.html
+++ b/geonode-client/templates/geonode-client/layer_map.html
@@ -44,32 +44,6 @@
       options.proxy = "{{PROXY_URL}}";
     }
     if ("{{ MAP_CLIENT_USE_CROSS_ORIGIN_CREDENTIALS }}" == 'True') {
-      var checkUrlCORSCompatible = function(url) {
-        return new Promise(function(resolve, reject) {
-          var xhr = new XMLHttpRequest();
-          var response;
-          xhr.open("GET", url, true);
-          xhr.withCredentials = true;
-          xhr.onload = function() {
-            if (this.status >= 200 && this.status < 400 && xhr.response != null) {
-              // We don't care as long as it worked
-              resolve(true);
-            } else {
-              reject({
-                status: this.status,
-                statusText: this.statusText
-              });
-            }
-          };
-          xhr.onerror = function() {
-            reject({
-              status: this.status,
-              statusText: this.statusText
-            });
-          };
-          xhr.send();
-        });
-      };
       var checkUrl = "{{ resource.service.base_url }}";
       checkUrlCORSCompatible(checkUrl).then(function(response) {
         options.crossOriginCredentials = true;

--- a/geonode-client/templates/geonode-client/layer_map.html
+++ b/geonode-client/templates/geonode-client/layer_map.html
@@ -44,7 +44,40 @@
       options.proxy = "{{PROXY_URL}}";
     }
     if ("{{ MAP_CLIENT_USE_CROSS_ORIGIN_CREDENTIALS }}" == 'True') {
-      options.crossOriginCredentials = true;
+      var checkUrlCORSCompatible = function(url) {
+        return new Promise(function(resolve, reject) {
+          var xhr = new XMLHttpRequest();
+          var response;
+          xhr.open("GET", url, true);
+          xhr.withCredentials = true;
+          xhr.onload = function() {
+            if (this.status >= 200 && this.status < 400 && xhr.response != null) {
+              // We don't care as long as it worked
+              resolve(true);
+            } else {
+              reject({
+                status: this.status,
+                statusText: this.statusText
+              });
+            }
+          };
+          xhr.onerror = function() {
+            reject({
+              status: this.status,
+              statusText: this.statusText
+            });
+          };
+          xhr.send();
+        });
+      };
+      var checkUrl = "{{ resource.service.base_url }}";
+      checkUrlCORSCompatible(checkUrl).then(function(response) {
+        options.crossOriginCredentials = true;
+      }).catch(function(err) {
+        console.log("Service {{ resource.service }} is not CORS compatible. Status error: ", err.statusText);
+        console.log("Therefore, making requests anonymously instead of with credentials");
+        options.crossOriginCredentials = false;
+      });
     } else {
       options.crossOriginCredentials = false;
     }

--- a/geonode-client/templates/geonode-client/map_detail.html
+++ b/geonode-client/templates/geonode-client/map_detail.html
@@ -46,32 +46,6 @@
       options.proxy = "{{PROXY_URL}}";
     }
     if ("{{ MAP_CLIENT_USE_CROSS_ORIGIN_CREDENTIALS }}" == 'True') {
-      var checkUrlCORSCompatible = function(url) {
-        return new Promise(function(resolve, reject) {
-          var xhr = new XMLHttpRequest();
-          var response;
-          xhr.open("GET", url, true);
-          xhr.withCredentials = true;
-          xhr.onload = function() {
-            if (this.status >= 200 && this.status < 400 && xhr.response != null) {
-              // We don't care as long as it worked
-              resolve(true);
-            } else {
-              reject({
-                status: this.status,
-                statusText: this.statusText
-              });
-            }
-          };
-          xhr.onerror = function() {
-            reject({
-              status: this.status,
-              statusText: this.statusText
-            });
-          };
-          xhr.send();
-        });
-      };
       options.crossOriginCredentials = true;
       var layers = [], urls = [];
       {% for layer in layers %}

--- a/geonode-client/templates/geonode-client/map_detail.html
+++ b/geonode-client/templates/geonode-client/map_detail.html
@@ -46,7 +46,51 @@
       options.proxy = "{{PROXY_URL}}";
     }
     if ("{{ MAP_CLIENT_USE_CROSS_ORIGIN_CREDENTIALS }}" == 'True') {
+      var checkUrlCORSCompatible = function(url) {
+        return new Promise(function(resolve, reject) {
+          var xhr = new XMLHttpRequest();
+          var response;
+          xhr.open("GET", url, true);
+          xhr.withCredentials = true;
+          xhr.onload = function() {
+            if (this.status >= 200 && this.status < 400 && xhr.response != null) {
+              // We don't care as long as it worked
+              resolve(true);
+            } else {
+              reject({
+                status: this.status,
+                statusText: this.statusText
+              });
+            }
+          };
+          xhr.onerror = function() {
+            reject({
+              status: this.status,
+              statusText: this.statusText
+            });
+          };
+          xhr.send();
+        });
+      };
       options.crossOriginCredentials = true;
+      var layers = [], urls = [];
+      {% for layer in layers %}
+      layers[{{ forloop.counter0 }}] = '{{ layer.name }}';
+      urls[{{ forloop.counter0 }}] = '{{ layer.ows_url }}';
+      {% endfor %}
+      for (var i = 0; i < urls.length; i++) {
+        // TODO: More robust solution requires CORS policy per layer instead of for whole map
+        if (options.crossOriginCredentials == true && urls[i] != 'None') {
+            checkUrlCORSCompatible(urls[i]).then(function(response) {
+                continue;
+            }).catch(function(err){
+                console.log("Layer " + layers[i] + "'s service (url: " + urls[i] + ") is not CORS compatible.");
+                console.log("Status error: ", err.statusText);
+                console.log("Therefore, making all requests anonymously instead of with credentials");
+                options.crossOriginCredentials = false;
+            });
+        }
+      }
     } else {
       options.crossOriginCredentials = false;
     }

--- a/geonode-client/templates/geonode-client/map_view.html
+++ b/geonode-client/templates/geonode-client/map_view.html
@@ -52,32 +52,6 @@
       options.proxy = "{{PROXY_URL}}";
     }
     if ("{{ MAP_CLIENT_USE_CROSS_ORIGIN_CREDENTIALS }}" == 'True') {
-      var checkUrlCORSCompatible = function(url) {
-        return new Promise(function(resolve, reject) {
-          var xhr = new XMLHttpRequest();
-          var response;
-          xhr.open("GET", url, true);
-          xhr.withCredentials = true;
-          xhr.onload = function() {
-            if (this.status >= 200 && this.status < 400 && xhr.response != null) {
-              // We don't care as long as it worked
-              resolve(true);
-            } else {
-              reject({
-                status: this.status,
-                statusText: this.statusText
-              });
-            }
-          };
-          xhr.onerror = function() {
-            reject({
-              status: this.status,
-              statusText: this.statusText
-            });
-          };
-          xhr.send();
-        });
-      };
       options.crossOriginCredentials = true;
       var layers = [], urls = [];
       {% for layer in layers %}

--- a/geonode-client/templates/geonode-client/map_view.html
+++ b/geonode-client/templates/geonode-client/map_view.html
@@ -52,7 +52,51 @@
       options.proxy = "{{PROXY_URL}}";
     }
     if ("{{ MAP_CLIENT_USE_CROSS_ORIGIN_CREDENTIALS }}" == 'True') {
+      var checkUrlCORSCompatible = function(url) {
+        return new Promise(function(resolve, reject) {
+          var xhr = new XMLHttpRequest();
+          var response;
+          xhr.open("GET", url, true);
+          xhr.withCredentials = true;
+          xhr.onload = function() {
+            if (this.status >= 200 && this.status < 400 && xhr.response != null) {
+              // We don't care as long as it worked
+              resolve(true);
+            } else {
+              reject({
+                status: this.status,
+                statusText: this.statusText
+              });
+            }
+          };
+          xhr.onerror = function() {
+            reject({
+              status: this.status,
+              statusText: this.statusText
+            });
+          };
+          xhr.send();
+        });
+      };
       options.crossOriginCredentials = true;
+      var layers = [], urls = [];
+      {% for layer in layers %}
+      layers[{{ forloop.counter0 }}] = '{{ layer.name }}';
+      urls[{{ forloop.counter0 }}] = '{{ layer.ows_url }}';
+      {% endfor %}
+      for (var i = 0; i < urls.length; i++) {
+        // TODO: More robust solution requires CORS policy per layer instead of for whole map
+        if (options.crossOriginCredentials == true && urls[i] != 'None') {
+            checkUrlCORSCompatible(urls[i]).then(function(response) {
+                continue;
+            }).catch(function(err){
+                console.log("Layer " + layers[i] + "'s service (url: " + urls[i] + ") is not CORS compatible.");
+                console.log("Status error: ", err.statusText);
+                console.log("Therefore, making all requests anonymously instead of with credentials");
+                options.crossOriginCredentials = false;
+            });
+        }
+      }
     } else {
       options.crossOriginCredentials = false;
     }

--- a/src/components/geonode.jsx
+++ b/src/components/geonode.jsx
@@ -33,6 +33,33 @@ import {getCRSFToken} from '../helper';
 import '../css/app.css'
 import '@boundlessgeo/sdk/dist/css/components.css';
 
+global.checkUrlCORSCompatible = function(url) {
+  return new Promise(function(resolve, reject) {
+    var xhr = new XMLHttpRequest();
+    var response;
+    xhr.open("GET", url, true);
+    xhr.withCredentials = true;
+    xhr.onload = function() {
+      if (this.status >= 200 && this.status < 400 && xhr.response != null) {
+        // We don't care as long as it worked
+        resolve(true);
+      } else {
+        reject({
+          status: this.status,
+          statusText: this.statusText
+        });
+      }
+    };
+    xhr.onerror = function() {
+      reject({
+        status: this.status,
+        statusText: this.statusText
+      });
+    };
+    xhr.send();
+  });
+};
+
 // Needed for onTouchTap
 // Can go away when react 1.0 release
 // Check this repo:


### PR DESCRIPTION
…t permit it

## Whart does this PR do?
Checks that the service URLs are compatible with a `use-credentials` CORS request before committing to it in the viewer.

## Screenshot
N/A

## Related Issue
N/A
